### PR TITLE
feature/support_gfs_ic_local

### DIFF
--- a/earth2mip/initial_conditions/gfs.py
+++ b/earth2mip/initial_conditions/gfs.py
@@ -426,7 +426,7 @@ def _get_gfs_name_dict() -> Dict[str, str]:
 
 
 class DataSource(base.DataSource):
-    def __init__(self, channels: List[str], download_ic=True) -> None:
+    def __init__(self, channels: List[str], download_ic: bool = True) -> None:
         lookup = _get_gfs_name_dict()
         self._gfs_channels = [lookup[c] for c in channels]
         self._channel_names = channels

--- a/earth2mip/initial_conditions/gfs.py
+++ b/earth2mip/initial_conditions/gfs.py
@@ -230,6 +230,7 @@ def get(
     # Clean up
     if download_gfs:
         shutil.rmtree(GFS_CACHE)
+	logger.info(f"Removing GFS initial conditions in {GFS_CACHE}")
     else:
         logger.info(f"Retaining GFS initial conditions in {GFS_CACHE}")
 

--- a/earth2mip/initial_conditions/gfs.py
+++ b/earth2mip/initial_conditions/gfs.py
@@ -224,7 +224,7 @@ def get(
         data[i] = field
 
     # Clean up
-    shutil.rmtree(GFS_CACHE)
+    # shutil.rmtree(GFS_CACHE)
 
     return data
 

--- a/earth2mip/initial_conditions/gfs.py
+++ b/earth2mip/initial_conditions/gfs.py
@@ -228,7 +228,10 @@ def get(
         data[i] = field
 
     # Clean up
-    # shutil.rmtree(GFS_CACHE)
+    if download_gfs:
+        shutil.rmtree(GFS_CACHE)
+    else:
+        logger.info(f"Retaining GFS initial conditions in {GFS_CACHE}")
 
     return data
 

--- a/earth2mip/initial_conditions/gfs.py
+++ b/earth2mip/initial_conditions/gfs.py
@@ -215,7 +215,7 @@ def get(
 		raise NotADirectoryError(f"Directory {GFS_CACHE} does not exist.")
 	# check that all necessary files are present 
 	for idname in tqdm(gfs_channels):
-		filepath = Path(f"{GFS_CACHE}/{idname}.grb")
+		filepath = pathlib.Path(f"{GFS_CACHE}/{idname}.grb")
 		if not filepath.is_file():
 			raise FileNotFoundError(f"Required IC file {filepath} is missing from {GFS_CACHE}")
         logger.info(f"GFS initial conditions already present, skipping download")

--- a/earth2mip/initial_conditions/gfs.py
+++ b/earth2mip/initial_conditions/gfs.py
@@ -209,7 +209,15 @@ def get(
         logger.info(f"Downloading {len(gfs_channels)} grib files:")
         for idname in tqdm(gfs_channels):
             get_gfs_grib_file(time_gfs, gfs_chunks, idname, f"{GFS_CACHE}/{idname}.grb")
-    else: 
+    else:
+	# ensure that cache folder exists
+	if not pathlib.Path(GFS_CACHE).exists():
+		raise NotADirectoryError(f"Directory {GFS_CACHE} does not exist.")
+	# check that all necessary files are present 
+	for idname in tqdm(gfs_channels):
+		filepath = Path(f"{GFS_CACHE}/{idname}.grb")
+		if not filepath.is_file():
+			raise FileNotFoundError(f"Required IC file {filepath} is missing from {GFS_CACHE}")
         logger.info(f"GFS initial conditions already present, skipping download")
 
     # Convert gribs to xarray dataset


### PR DESCRIPTION
This PR adds explicit support for decoupling IC ingestion from ensemble inference for GFS (other IC data sources forthcoming) by adding a `download_ic` flag to the `DataSource` class instantiation for GFS. It can be used as such: 

```
from earth2mip.initial_conditions import gfs
data_source = gfs.DataSource(time_loop.in_channel_names, download_ic=True)
```

Default is `True` which continues to request and subsequently download GFS initial conditions (and is backwards compatible). If set to `False`, instead the GFS initial conditions for the specified datetime are used from the local directory specified by `GFS_CACHE`, e.g. `$HOME/.cache/modulus/earth2mip/gfs`. 

