### PR TITLE
Feature/ifs_control _and_ensemble support

### DIFF
--- a/earth2mip/initial_conditions/__init__.py
+++ b/earth2mip/initial_conditions/__init__.py
@@ -94,12 +94,14 @@ def get_data_from_source(
 
     index = [data_source.channel_names.index(c) for c in channel_names]
     values = np.take(array, index, axis=1)
-    regridder = regrid.get_regridder(data_source.grid, grid).to(device)
+    # TO-DO: don't regrid if IC resolution already same as model resolution
+    # regridder = regrid.get_regridder(data_source.grid, grid).to(device)
     x = torch.from_numpy(values).to(device).type(dtype)
     # need a batch dimension of length 1
     # make an empty batch dim
     x = x[None]
-    x = regridder(x)
+    # TO-DO: make below statement conditional on differing resolutions 
+    # x = regridder(x)
     return x
 
 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -66,49 +66,6 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     dataset_pf = [ds for ds in dataset_0h if 0 not in ds['number']]
     dataset_cf = [ds for ds in dataset_0h if 0 in ds['number']]
 
-    """
-    if ensemble_member == 0:
-        channel_data = [
-            _get_channel(
-                c,
-                u10m=[ds['u10'] for ds in dataset_cf if 'u10' in ds.data_vars][0],
-                v10m=[ds['v10'] for ds in dataset_cf if 'v10' in ds.data_vars][0],
-                u100m=[ds['u100'] for ds in dataset_cf if 'u100' in ds.data_vars][0],
-                v100m=[ds['v100'] for ds in dataset_cf if 'v100' in ds.data_vars][0],
-                sp=[ds['sp']  for ds in dataset_cf if 'sp' in ds.data_vars][0],
-                t2m=[ds['t2m'] for ds in dataset_cf if 't2m' in ds.data_vars][0],
-                msl=[ds['msl'] for ds in dataset_cf if 'msl' in ds.data_vars][0],
-                tcwv=[ds['tcwv'] for ds in dataset_cf if 'tcwv' in ds.data_vars][0],
-                t=[ds['t'] for ds in dataset_cf if 't' in ds.data_vars][0],
-                u=[ds['u'] for ds in dataset_cf if 'u' in ds.data_vars][0],
-                v=[ds['v'] for ds in dataset_cf if 'v' in ds.data_vars][0],
-                r=[ds['r'] for ds in dataset_cf if 'r' in ds.data_vars][0],
-                z=[ds['gh'] for ds in dataset_cf if 'gh' in ds.data_vars][0] * 9.81,
-            )
-            for c in channels
-        ]
-    else: 
-        channel_data = [
-            _get_channel(
-                c,
-                u10m=[ds['u10'] for ds in dataset_pf if 'u10' in ds.data_vars][0].sel(number=ensemble_member),
-                v10m=[ds['v10'] for ds in dataset_pf if 'v10' in ds.data_vars][0].sel(number=ensemble_member),
-                u100m=[ds['u100'] for ds in dataset_pf if 'u100' in ds.data_vars][0].sel(number=ensemble_member),
-                v100m=[ds['v100'] for ds in dataset_pf if 'v100' in ds.data_vars][0].sel(number=ensemble_member),
-                sp=[ds['sp']  for ds in dataset_pf if 'sp' in ds.data_vars][0].sel(number=ensemble_member),
-                t2m=[ds['t2m'] for ds in dataset_pf if 't2m' in ds.data_vars][0].sel(number=ensemble_member),
-                msl=[ds['msl'] for ds in dataset_pf if 'msl' in ds.data_vars][0].sel(number=ensemble_member),
-                tcwv=[ds['tcwv'] for ds in dataset_pf if 'tcwv' in ds.data_vars][0].sel(number=ensemble_member),
-                t=[ds['t'] for ds in dataset_pf if 't' in ds.data_vars][0].sel(number=ensemble_member),
-                u=[ds['u'] for ds in dataset_pf if 'u' in ds.data_vars][0].sel(number=ensemble_member),
-                v=[ds['v'] for ds in dataset_pf if 'v' in ds.data_vars][0].sel(number=ensemble_member),
-                r=[ds['r'] for ds in dataset_pf if 'r' in ds.data_vars][0].sel(number=ensemble_member),
-                z=[ds['gh'] for ds in dataset_pf if 'gh' in ds.data_vars][0].sel(number=ensemble_member) * 9.81,
-            )
-            for c in channels
-        ]
-    """
-
     channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
 
     if ensemble_member == 0:

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -52,10 +52,6 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
 
 
 def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
-    # this data product is outdated (as of 10/2024) and no longer exists
-    # also it is no longer necessary to get these data files separately
-    # either update to GCS or completely rely on local files
-    # root = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/"
     root = "/dev/shm/"
     # oper for testing
     # filename = "20241020120000-0h-oper-fc.grib2"
@@ -64,17 +60,12 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
     #path = root + _get_filename(time, "0h")
     path = root + filename
     print("path is {}".format(path))
-    # local_path = filesystem._download_cached(path)
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
 
-    # try to get control forecast
-    # dataset_cf = cfgrib.open_datasets(path, filter_by_keys={'type': 'cf', 'shortName': 'cf', 'indexpath': ''})
-    # dataset_cf = xarray.open_datasets(path, engine='cfgrib', backend_kwargs={'filter_by_keys': {'type': 'cf'}})
+    # split control forecast and perturbed forecasts 
     dataset_pf = [ds for ds in dataset_0h if 0 not in ds['number']]
     dataset_cf = [ds for ds in dataset_0h if 0 in ds['number']]
-    # get t2m and other things from 12 hour forecast initialized 12 hours before
-    # The HRES is only initialized every 12 hours
     #path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
     #local_path = filesystem._download_cached(path)
 
@@ -159,17 +150,13 @@ class DataSource(base.DataSource):
 
     def __getitem__(self, time: datetime.datetime) -> np.ndarray:
         ds = get(time, self.channel_names, self.ensemble_member)
-        # ds = ds.expand_dims("time", axis=0)
-        # move to earth2mip.channels
 
-        # TODO refactor interpolation to another place
+        # move to earth2mip.channels
         metadata = json.loads(METADATA.read_text())
         lat = np.array(metadata["coords"]["lat"])
         lon = np.array(metadata["coords"]["lon"])
         ds = ds.roll(lon=len(ds.lon) // 2, roll_coords=True)
-        print("rolled longitudes") 
         ds["lon"] = ds.lon.where(ds.lon >= 0, ds.lon + 360)
-        print("reassigned rolled longitudes")
         assert min(ds.lon) >= 0, min(ds.lon)  # noqa
         # return ds.interp(lat=lat, lon=lon, kwargs={"fill_value": "extrapolate"})
         return ds

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -120,26 +120,22 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
         ]
 
     # dataset_0h is list of Datasets, grab first one 
-    # for creating new array
+    # for creating new array, variable doesn't matter 
     ds_ex = dataset_0h[0]
 
     array = np.stack([d for d in channel_data], axis=0)
-    print("shape of array is {}".format(array.shape))
+    
     darray = xarray.DataArray(
         array,
         dims=["channel", "lat", "lon"],
-        # dims=["channel", "ensemble_member", "lat", "lon"],
         coords={
             "channel": channels,
-            # "ensemble_member": ds_ex.number.values,
-            # "lon": dataset_0h.longitude.values,
             "lon": ds_ex.longitude.values,
-            #"lat": dataset_0h.latitude.values,
             "lat": ds_ex.latitude.values,
             "time": time,
         },
     )
-    print("created array")
+    
     return darray
 
 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -71,15 +71,12 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
     # try to get control forecast
     # dataset_cf = cfgrib.open_datasets(path, filter_by_keys={'type': 'cf', 'shortName': 'cf', 'indexpath': ''})
     # dataset_cf = xarray.open_datasets(path, engine='cfgrib', backend_kwargs={'filter_by_keys': {'type': 'cf'}})
+    dataset_pf = [ds for ds in dataset_0h if 0 not in ds['number']]
     dataset_cf = [ds for ds in dataset_0h if 0 in ds['number']]
     # get t2m and other things from 12 hour forecast initialized 12 hours before
     # The HRES is only initialized every 12 hours
     #path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
     #local_path = filesystem._download_cached(path)
-
-    print("trying to find control forecast")
-    # print([ds['u10'] for ds in dataset_0h if ('u10' in ds.data_vars) & (ds.dims.type == 'cf')][0])
-    print(dataset_cf)
 
     channel_data = [
         _get_channel(

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -58,7 +58,7 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
 
 def get(time: datetime.datetime, channels: List[str], ensemble_member: int, 
         root_path: str): -> xarray.DataArray:
-    path = root_path + _get_filename(time, "0h")
+    path = os.path.join(root_path, _get_filename(time, "0h"))
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -66,6 +66,7 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     dataset_pf = [ds for ds in dataset_0h if 0 not in ds['number']]
     dataset_cf = [ds for ds in dataset_0h if 0 in ds['number']]
 
+    """
     if ensemble_member == 0:
         channel_data = [
             _get_channel(
@@ -106,6 +107,27 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
             )
             for c in channels
         ]
+    """
+
+    channel_vars = ['u10', 'v10', 'u100', 'v100', 'sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
+
+    if ensemble_member == 0:
+        dset = [ds for ds in dataset_0h if 0 in ds['number']]
+        def _subset(varname):
+            return [ds[varname] for ds in dset if varname in ds.data_vars][0]
+    else:
+        dset = [ds for ds in dataset_0h if 0 not in ds['number']]
+        def _subset(varname):
+            return [ds[varname] for ds in dset if varname in ds.data_vars][0].sel(number=ensemble_member)
+
+    channel_data = [
+        _get_channel(
+            c, 
+            **{var: _subset(var) for var in channel_vars},
+            z=_subset('gh') * 9.81,
+        )   
+        for c in channels
+    ] 
 
     # dataset_0h is list of Datasets, grab first one 
     # for creating new array, variable doesn't matter 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -29,7 +29,10 @@ from earth2mip.datasets.era5 import METADATA
 from earth2mip.initial_conditions import base
 
 
-def _get_filename(time: datetime.datetime, lead_time: str):
+def _get_filename(time: datetime.datetime, lead_time: str): -> str:
+    """
+    Returns the IFS forecast grib file given the specified datetime and lead time.
+    """
     file_format = f"%Y%m%d%H0000-{lead_time}-enfo-ef.grib2"
     return time.strftime(file_format)
 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -19,7 +19,7 @@ import datetime
 import json
 import cfgrib
 from typing import List
-
+import os
 import numpy as np
 import xarray
 from modulus.utils import filesystem
@@ -29,7 +29,7 @@ from earth2mip.datasets.era5 import METADATA
 from earth2mip.initial_conditions import base
 
 
-def _get_filename(time: datetime.datetime, lead_time: str): -> str:
+def _get_filename(time: datetime.datetime, lead_time: str) -> str:
     """
     Returns the IFS forecast grib file containing control and perturbed forecasts
     given the specified datetime and lead time.
@@ -57,7 +57,7 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
 
 
 def get(time: datetime.datetime, channels: List[str], ensemble_member: int, 
-        root_path: str): -> xarray.DataArray:
+        root_path: str) -> xarray.DataArray:
     path = os.path.join(root_path, _get_filename(time, "0h"))
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
@@ -109,7 +109,7 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
         ]
     """
 
-    channel_vars = ['u10', 'v10', 'u100', 'v100', 'sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
+    channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
 
     if ensemble_member == 0:
         dset = [ds for ds in dataset_0h if 0 in ds['number']]
@@ -124,6 +124,10 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
         _get_channel(
             c, 
             **{var: _subset(var) for var in channel_vars},
+            u10m=_subset('u10'),
+            v10m=_subset('v10'),
+            u100m=_subset('u100'),
+            v100m=_subset('v100'),
             z=_subset('gh') * 9.81,
         )   
         for c in channels

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -123,7 +123,7 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
 
 @dataclasses.dataclass
 class DataSource(base.DataSource):
-    def __init__(self, channel_names: List[str], from_path: str, ensemble_member: int = 1):
+    def __init__(self, channel_names: List[str], from_path: str, ensemble_member: int = 0):
         self._channel_names = channel_names
         self._ensemble_member = ensemble_member
         self._root_path = from_path

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -17,6 +17,7 @@
 import dataclasses
 import datetime
 import json
+import cfgrib
 from typing import List
 
 import numpy as np
@@ -29,7 +30,8 @@ from earth2mip.initial_conditions import base
 
 
 def _get_filename(time: datetime.datetime, lead_time: str):
-    date_format = f"%Y%m%d/%Hz/0p4-beta/oper/%Y%m%d%H%M%S-{lead_time}-oper-fc.grib2"
+    # date_format = f"%Y%m%d/%Hz/0p4-beta/oper/%Y%m%d%H%M%S-{lead_time}-oper-fc.grib2"
+    date_format = f"%Y%m%d/%Hz/ifs/0p4-beta/oper/%Y%m%d%H%M%S-{lead_time}-oper-fc.grib2"
     return time.strftime(date_format)
 
 
@@ -43,55 +45,103 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
     """
     # handle 2d inputs
     if c in kwargs:
+        print("returning {} in kwargs".format(c))
         return kwargs[c]
     else:
         varcode, pressure_level = c[0], int(c[1:])
+        print("providing {} andd {}".format(varcode, pressure_level))
         return kwargs[varcode].interp(isobaricInhPa=pressure_level)
 
 
 def get(time: datetime.datetime, channels: List[str]):
-    root = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/"
-    path = root + _get_filename(time, "0h")
-    local_path = filesystem._download_cached(path)
-    dataset_0h = xarray.open_dataset(local_path, engine="cfgrib")
+    # this data product is outdated (as of 10/2024) and no longer exists
+    # also it is no longer necessary to get these data files separately
+    # either update to GCS or completely rely on local files
+    # root = "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/"
+    root = "/dev/shm/"
+    # oper for testing
+    # filename = "20241020120000-0h-oper-fc.grib2"
+    # ifs ensemble 
+    filename = "20241020120000-0h-enfo-ef.grib2"
+    #path = root + _get_filename(time, "0h")
+    path = root + filename
+    print("path is {}".format(path))
+    # local_path = filesystem._download_cached(path)
+    # dataset_0h = xarray.open_dataset(local_path, engine="cfgrib")
+    #dataset_0h = xarray.open_dataset(path, filter_by_keys={'dataType': 'pf', 'typeOfLevel': 'heightAboveGround', 'level': 2}, engine="cfgrib")
+    dataset_0h = cfgrib.open_datasets(path)
 
+    ## TO-DO add as argument
+    ensemble_member = 2
+
+    # print(dataset_0h)
+    print([ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0])
+    print([ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0].sel(number=ensemble_member))
+    # print(dataset_0h.data_vars)
     # get t2m and other things from 12 hour forecast initialized 12 hours before
     # The HRES is only initialized every 12 hours
-    path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
-    local_path = filesystem._download_cached(path)
-    forecast_12h = xarray.open_dataset(local_path, engine="cfgrib")
+    #path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
+    #print("second filepath is {}".format(path))
+    #local_path = filesystem._download_cached(path)
+    #forecast_12h = xarray.open_dataset(local_path, engine="cfgrib")
 
     channel_data = [
         _get_channel(
             c,
-            u10m=dataset_0h.u10,
-            v10m=dataset_0h.v10,
-            u100m=dataset_0h.u10,
-            v100m=dataset_0h.v10,
-            sp=dataset_0h.sp,
-            t2m=forecast_12h.t2m,
-            msl=forecast_12h.msl,
-            tcwv=forecast_12h.tciwv,
-            t=dataset_0h.t,
-            u=dataset_0h.u,
-            v=dataset_0h.v,
-            r=dataset_0h.r,
-            z=dataset_0h.gh * 9.81,
+            #u10m=dataset_0h.u10,
+            u10m=[ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0].sel(number=ensemble_member),
+            #v10m=dataset_0h.v10,
+            v10m=[ds['v10'] for ds in dataset_0h if 'v10' in ds.data_vars][0].sel(number=ensemble_member),
+            # u100m=dataset_0h.u10,
+            u100m=[ds['u100'] for ds in dataset_0h if 'u100' in ds.data_vars][0].sel(number=ensemble_member),
+            #v100m=dataset_0h.v10,
+            v100m=[ds['v100'] for ds in dataset_0h if 'v100' in ds.data_vars][0].sel(number=ensemble_member),
+            #sp=dataset_0h.sp,
+            sp=[ds['sp']  for ds in dataset_0h if 'sp' in ds.data_vars][0].sel(number=ensemble_member),
+            # t2m=forecast_12h.t2m,
+            #t2m=dataset_0h.t2m,
+            t2m=[ds['t2m'] for ds in dataset_0h if 't2m' in ds.data_vars][0].sel(number=ensemble_member),
+            #msl=forecast_12h.msl,
+            #msl=dataset_0h.msl,
+            msl=[ds['msl'] for ds in dataset_0h if 'msl' in ds.data_vars][0].sel(number=ensemble_member),
+            # tcwv=forecast_12h.tciwv,
+            #tcwv=dataset_0h.tciwv,
+            tcwv=[ds['tcwv'] for ds in dataset_0h if 'tcwv' in ds.data_vars][0].sel(number=ensemble_member),
+            #t=dataset_0h.t,
+            t=[ds['t'] for ds in dataset_0h if 't' in ds.data_vars][0].sel(number=ensemble_member),
+            #u=dataset_0h.u,
+            u=[ds['u'] for ds in dataset_0h if 'u' in ds.data_vars][0].sel(number=ensemble_member),
+            #v=dataset_0h.v,
+            v=[ds['v'] for ds in dataset_0h if 'v' in ds.data_vars][0].sel(number=ensemble_member),
+            #r=dataset_0h.r,
+            r=[ds['r'] for ds in dataset_0h if 'r' in ds.data_vars][0].sel(number=ensemble_member),
+            #z=dataset_0h.gh * 9.81,
+            z=[ds['gh'] for ds in dataset_0h if 'gh' in ds.data_vars][0].sel(number=ensemble_member) * 9.81,
         )
         for c in channels
     ]
 
+    # dataset_0h is list of Datasets, grab first one 
+    # for creating new array
+    ds_ex = dataset_0h[0]
+
     array = np.stack([d for d in channel_data], axis=0)
+    print("shape of array is {}".format(array.shape))
     darray = xarray.DataArray(
         array,
         dims=["channel", "lat", "lon"],
+        # dims=["channel", "ensemble_member", "lat", "lon"],
         coords={
             "channel": channels,
-            "lon": dataset_0h.longitude.values,
-            "lat": dataset_0h.latitude.values,
+            # "ensemble_member": ds_ex.number.values,
+            # "lon": dataset_0h.longitude.values,
+            "lon": ds_ex.longitude.values,
+            #"lat": dataset_0h.latitude.values,
+            "lat": ds_ex.latitude.values,
             "time": time,
         },
     )
+    print("created array")
     return darray
 
 
@@ -110,7 +160,7 @@ class DataSource(base.DataSource):
 
     def __getitem__(self, time: datetime.datetime) -> np.ndarray:
         ds = get(time, self.channel_names)
-        ds = ds.expand_dims("time", axis=0)
+        # ds = ds.expand_dims("time", axis=0)
         # move to earth2mip.channels
 
         # TODO refactor interpolation to another place
@@ -118,6 +168,9 @@ class DataSource(base.DataSource):
         lat = np.array(metadata["coords"]["lat"])
         lon = np.array(metadata["coords"]["lon"])
         ds = ds.roll(lon=len(ds.lon) // 2, roll_coords=True)
+        print("rolled longitudes") 
         ds["lon"] = ds.lon.where(ds.lon >= 0, ds.lon + 360)
+        print("reassigned rolled longitudes")
         assert min(ds.lon) >= 0, min(ds.lon)  # noqa
-        return ds.interp(lat=lat, lon=lon, kwargs={"fill_value": "extrapolate"})
+        # return ds.interp(lat=lat, lon=lon, kwargs={"fill_value": "extrapolate"})
+        return ds

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -31,7 +31,10 @@ from earth2mip.initial_conditions import base
 
 def _get_filename(time: datetime.datetime, lead_time: str): -> str:
     """
-    Returns the IFS forecast grib file given the specified datetime and lead time.
+    Returns the IFS forecast grib file containing control and perturbed forecasts
+    given the specified datetime and lead time.
+    Note that the filename format is specific to the ECMWF IFS forecasts,
+    and may need to be adjusted for future versions.
     """
     file_format = f"%Y%m%d%H0000-{lead_time}-enfo-ef.grib2"
     return time.strftime(file_format)

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -53,7 +53,7 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
         return kwargs[varcode].interp(isobaricInhPa=pressure_level)
 
 
-def get(time: datetime.datetime, channels: List[str]):
+def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
     # this data product is outdated (as of 10/2024) and no longer exists
     # also it is no longer necessary to get these data files separately
     # either update to GCS or completely rely on local files
@@ -147,8 +147,9 @@ def get(time: datetime.datetime, channels: List[str]):
 
 @dataclasses.dataclass
 class DataSource(base.DataSource):
-    def __init__(self, channel_names: List[str]):
+    def __init__(self, channel_names: List[str], ensemble_member: int = 1):
         self._channel_names = channel_names
+        self._ensemble_member = ensemble_member
 
     @property
     def channel_names(self) -> List[str]:
@@ -159,7 +160,7 @@ class DataSource(base.DataSource):
         return earth2mip.grid.equiangular_lat_lon_grid(721, 1440)
 
     def __getitem__(self, time: datetime.datetime) -> np.ndarray:
-        ds = get(time, self.channel_names)
+        ds = get(time, self.channel_names, self.ensemble_member)
         # ds = ds.expand_dims("time", axis=0)
         # move to earth2mip.channels
 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -45,11 +45,9 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
     """
     # handle 2d inputs
     if c in kwargs:
-        print("returning {} in kwargs".format(c))
         return kwargs[c]
     else:
         varcode, pressure_level = c[0], int(c[1:])
-        print("providing {} andd {}".format(varcode, pressure_level))
         return kwargs[varcode].interp(isobaricInhPa=pressure_level)
 
 
@@ -71,19 +69,10 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
     #dataset_0h = xarray.open_dataset(path, filter_by_keys={'dataType': 'pf', 'typeOfLevel': 'heightAboveGround', 'level': 2}, engine="cfgrib")
     dataset_0h = cfgrib.open_datasets(path)
 
-    ## TO-DO add as argument
-    # ensemble_member = 2
-
-    # print(dataset_0h)
-    print([ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0])
-    print([ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0].sel(number=ensemble_member))
-    # print(dataset_0h.data_vars)
     # get t2m and other things from 12 hour forecast initialized 12 hours before
     # The HRES is only initialized every 12 hours
     #path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
-    #print("second filepath is {}".format(path))
     #local_path = filesystem._download_cached(path)
-    #forecast_12h = xarray.open_dataset(local_path, engine="cfgrib")
 
     channel_data = [
         _get_channel(

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -62,21 +62,20 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
 
-    # split control forecast and perturbed forecasts 
-    dataset_pf = [ds for ds in dataset_0h if 0 not in ds['number']]
-    dataset_cf = [ds for ds in dataset_0h if 0 in ds['number']]
-
-    channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
-
     if ensemble_member == 0:
+        # control forecast
         dset = [ds for ds in dataset_0h if 0 in ds['number']]
         def _subset(varname):
             return [ds[varname] for ds in dset if varname in ds.data_vars][0]
     else:
+        # perturbed forecasts
         dset = [ds for ds in dataset_0h if 0 not in ds['number']]
         def _subset(varname):
             return [ds[varname] for ds in dset if varname in ds.data_vars][0].sel(number=ensemble_member)
 
+    # channel variables that do not require renaming
+    channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
+    
     channel_data = [
         _get_channel(
             c, 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -65,46 +65,37 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
     path = root + filename
     print("path is {}".format(path))
     # local_path = filesystem._download_cached(path)
-    # dataset_0h = xarray.open_dataset(local_path, engine="cfgrib")
-    #dataset_0h = xarray.open_dataset(path, filter_by_keys={'dataType': 'pf', 'typeOfLevel': 'heightAboveGround', 'level': 2}, engine="cfgrib")
+    # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
 
+    # try to get control forecast
+    # dataset_cf = cfgrib.open_datasets(path, filter_by_keys={'type': 'cf', 'shortName': 'cf', 'indexpath': ''})
+    # dataset_cf = xarray.open_datasets(path, engine='cfgrib', backend_kwargs={'filter_by_keys': {'type': 'cf'}})
+    dataset_cf = [ds for ds in dataset_0h if 0 in ds['number']]
     # get t2m and other things from 12 hour forecast initialized 12 hours before
     # The HRES is only initialized every 12 hours
     #path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
     #local_path = filesystem._download_cached(path)
 
+    print("trying to find control forecast")
+    # print([ds['u10'] for ds in dataset_0h if ('u10' in ds.data_vars) & (ds.dims.type == 'cf')][0])
+    print(dataset_cf)
+
     channel_data = [
         _get_channel(
             c,
-            #u10m=dataset_0h.u10,
             u10m=[ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0].sel(number=ensemble_member),
-            #v10m=dataset_0h.v10,
             v10m=[ds['v10'] for ds in dataset_0h if 'v10' in ds.data_vars][0].sel(number=ensemble_member),
-            # u100m=dataset_0h.u10,
             u100m=[ds['u100'] for ds in dataset_0h if 'u100' in ds.data_vars][0].sel(number=ensemble_member),
-            #v100m=dataset_0h.v10,
             v100m=[ds['v100'] for ds in dataset_0h if 'v100' in ds.data_vars][0].sel(number=ensemble_member),
-            #sp=dataset_0h.sp,
             sp=[ds['sp']  for ds in dataset_0h if 'sp' in ds.data_vars][0].sel(number=ensemble_member),
-            # t2m=forecast_12h.t2m,
-            #t2m=dataset_0h.t2m,
             t2m=[ds['t2m'] for ds in dataset_0h if 't2m' in ds.data_vars][0].sel(number=ensemble_member),
-            #msl=forecast_12h.msl,
-            #msl=dataset_0h.msl,
             msl=[ds['msl'] for ds in dataset_0h if 'msl' in ds.data_vars][0].sel(number=ensemble_member),
-            # tcwv=forecast_12h.tciwv,
-            #tcwv=dataset_0h.tciwv,
             tcwv=[ds['tcwv'] for ds in dataset_0h if 'tcwv' in ds.data_vars][0].sel(number=ensemble_member),
-            #t=dataset_0h.t,
             t=[ds['t'] for ds in dataset_0h if 't' in ds.data_vars][0].sel(number=ensemble_member),
-            #u=dataset_0h.u,
             u=[ds['u'] for ds in dataset_0h if 'u' in ds.data_vars][0].sel(number=ensemble_member),
-            #v=dataset_0h.v,
             v=[ds['v'] for ds in dataset_0h if 'v' in ds.data_vars][0].sel(number=ensemble_member),
-            #r=dataset_0h.r,
             r=[ds['r'] for ds in dataset_0h if 'r' in ds.data_vars][0].sel(number=ensemble_member),
-            #z=dataset_0h.gh * 9.81,
             z=[ds['gh'] for ds in dataset_0h if 'gh' in ds.data_vars][0].sel(number=ensemble_member) * 9.81,
         )
         for c in channels

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -72,7 +72,7 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
     dataset_0h = cfgrib.open_datasets(path)
 
     ## TO-DO add as argument
-    ensemble_member = 2
+    # ensemble_member = 2
 
     # print(dataset_0h)
     print([ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0])
@@ -154,6 +154,10 @@ class DataSource(base.DataSource):
     @property
     def channel_names(self) -> List[str]:
         return self._channel_names
+
+    @property
+    def ensemble_member(self) -> int:
+        return self._ensemble_member
 
     @property
     def grid(self) -> earth2mip.grid.LatLonGrid:

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -30,9 +30,8 @@ from earth2mip.initial_conditions import base
 
 
 def _get_filename(time: datetime.datetime, lead_time: str):
-    # date_format = f"%Y%m%d/%Hz/0p4-beta/oper/%Y%m%d%H%M%S-{lead_time}-oper-fc.grib2"
-    date_format = f"%Y%m%d/%Hz/ifs/0p4-beta/oper/%Y%m%d%H%M%S-{lead_time}-oper-fc.grib2"
-    return time.strftime(date_format)
+    file_format = f"%Y%m%d%H0000-{lead_time}-enfo-ef.grib2"
+    return time.strftime(file_format)
 
 
 def _get_channel(c: str, **kwargs) -> xarray.DataArray:
@@ -51,23 +50,15 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
         return kwargs[varcode].interp(isobaricInhPa=pressure_level)
 
 
-def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
-    root = "/dev/shm/"
-    # oper for testing
-    # filename = "20241020120000-0h-oper-fc.grib2"
-    # ifs ensemble 
-    filename = "20241020120000-0h-enfo-ef.grib2"
-    #path = root + _get_filename(time, "0h")
-    path = root + filename
-    print("path is {}".format(path))
+def get(time: datetime.datetime, channels: List[str], ensemble_member: int, 
+        root_path: str):
+    path = root_path + _get_filename(time, "0h")
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
 
     # split control forecast and perturbed forecasts 
     dataset_pf = [ds for ds in dataset_0h if 0 not in ds['number']]
     dataset_cf = [ds for ds in dataset_0h if 0 in ds['number']]
-    #path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
-    #local_path = filesystem._download_cached(path)
 
     if ensemble_member == 0:
         channel_data = [
@@ -132,9 +123,10 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
 
 @dataclasses.dataclass
 class DataSource(base.DataSource):
-    def __init__(self, channel_names: List[str], ensemble_member: int = 1):
+    def __init__(self, channel_names: List[str], from_path: str, ensemble_member: int = 1):
         self._channel_names = channel_names
         self._ensemble_member = ensemble_member
+        self._root_path = from_path
 
     @property
     def channel_names(self) -> List[str]:
@@ -145,11 +137,16 @@ class DataSource(base.DataSource):
         return self._ensemble_member
 
     @property
+    def root_path(self) -> str:
+        return self._root_path
+
+    @property
     def grid(self) -> earth2mip.grid.LatLonGrid:
         return earth2mip.grid.equiangular_lat_lon_grid(721, 1440)
 
     def __getitem__(self, time: datetime.datetime) -> np.ndarray:
-        ds = get(time, self.channel_names, self.ensemble_member)
+        ds = get(time, self.channel_names, self.ensemble_member, 
+                self.root_path)
 
         # move to earth2mip.channels
         metadata = json.loads(METADATA.read_text())
@@ -158,5 +155,4 @@ class DataSource(base.DataSource):
         ds = ds.roll(lon=len(ds.lon) // 2, roll_coords=True)
         ds["lon"] = ds.lon.where(ds.lon >= 0, ds.lon + 360)
         assert min(ds.lon) >= 0, min(ds.lon)  # noqa
-        # return ds.interp(lat=lat, lon=lon, kwargs={"fill_value": "extrapolate"})
         return ds

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -51,7 +51,7 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
 
 
 def get(time: datetime.datetime, channels: List[str], ensemble_member: int, 
-        root_path: str):
+        root_path: str): -> xarray.DataArray:
     path = root_path + _get_filename(time, "0h")
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -78,25 +78,46 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int):
     #path = root + _get_filename(time - datetime.timedelta(hours=12), "12h")
     #local_path = filesystem._download_cached(path)
 
-    channel_data = [
-        _get_channel(
-            c,
-            u10m=[ds['u10'] for ds in dataset_0h if 'u10' in ds.data_vars][0].sel(number=ensemble_member),
-            v10m=[ds['v10'] for ds in dataset_0h if 'v10' in ds.data_vars][0].sel(number=ensemble_member),
-            u100m=[ds['u100'] for ds in dataset_0h if 'u100' in ds.data_vars][0].sel(number=ensemble_member),
-            v100m=[ds['v100'] for ds in dataset_0h if 'v100' in ds.data_vars][0].sel(number=ensemble_member),
-            sp=[ds['sp']  for ds in dataset_0h if 'sp' in ds.data_vars][0].sel(number=ensemble_member),
-            t2m=[ds['t2m'] for ds in dataset_0h if 't2m' in ds.data_vars][0].sel(number=ensemble_member),
-            msl=[ds['msl'] for ds in dataset_0h if 'msl' in ds.data_vars][0].sel(number=ensemble_member),
-            tcwv=[ds['tcwv'] for ds in dataset_0h if 'tcwv' in ds.data_vars][0].sel(number=ensemble_member),
-            t=[ds['t'] for ds in dataset_0h if 't' in ds.data_vars][0].sel(number=ensemble_member),
-            u=[ds['u'] for ds in dataset_0h if 'u' in ds.data_vars][0].sel(number=ensemble_member),
-            v=[ds['v'] for ds in dataset_0h if 'v' in ds.data_vars][0].sel(number=ensemble_member),
-            r=[ds['r'] for ds in dataset_0h if 'r' in ds.data_vars][0].sel(number=ensemble_member),
-            z=[ds['gh'] for ds in dataset_0h if 'gh' in ds.data_vars][0].sel(number=ensemble_member) * 9.81,
-        )
-        for c in channels
-    ]
+    if ensemble_member == 0:
+        channel_data = [
+            _get_channel(
+                c,
+                u10m=[ds['u10'] for ds in dataset_cf if 'u10' in ds.data_vars][0],
+                v10m=[ds['v10'] for ds in dataset_cf if 'v10' in ds.data_vars][0],
+                u100m=[ds['u100'] for ds in dataset_cf if 'u100' in ds.data_vars][0],
+                v100m=[ds['v100'] for ds in dataset_cf if 'v100' in ds.data_vars][0],
+                sp=[ds['sp']  for ds in dataset_cf if 'sp' in ds.data_vars][0],
+                t2m=[ds['t2m'] for ds in dataset_cf if 't2m' in ds.data_vars][0],
+                msl=[ds['msl'] for ds in dataset_cf if 'msl' in ds.data_vars][0],
+                tcwv=[ds['tcwv'] for ds in dataset_cf if 'tcwv' in ds.data_vars][0],
+                t=[ds['t'] for ds in dataset_cf if 't' in ds.data_vars][0],
+                u=[ds['u'] for ds in dataset_cf if 'u' in ds.data_vars][0],
+                v=[ds['v'] for ds in dataset_cf if 'v' in ds.data_vars][0],
+                r=[ds['r'] for ds in dataset_cf if 'r' in ds.data_vars][0],
+                z=[ds['gh'] for ds in dataset_cf if 'gh' in ds.data_vars][0] * 9.81,
+            )
+            for c in channels
+        ]
+    else: 
+        channel_data = [
+            _get_channel(
+                c,
+                u10m=[ds['u10'] for ds in dataset_pf if 'u10' in ds.data_vars][0].sel(number=ensemble_member),
+                v10m=[ds['v10'] for ds in dataset_pf if 'v10' in ds.data_vars][0].sel(number=ensemble_member),
+                u100m=[ds['u100'] for ds in dataset_pf if 'u100' in ds.data_vars][0].sel(number=ensemble_member),
+                v100m=[ds['v100'] for ds in dataset_pf if 'v100' in ds.data_vars][0].sel(number=ensemble_member),
+                sp=[ds['sp']  for ds in dataset_pf if 'sp' in ds.data_vars][0].sel(number=ensemble_member),
+                t2m=[ds['t2m'] for ds in dataset_pf if 't2m' in ds.data_vars][0].sel(number=ensemble_member),
+                msl=[ds['msl'] for ds in dataset_pf if 'msl' in ds.data_vars][0].sel(number=ensemble_member),
+                tcwv=[ds['tcwv'] for ds in dataset_pf if 'tcwv' in ds.data_vars][0].sel(number=ensemble_member),
+                t=[ds['t'] for ds in dataset_pf if 't' in ds.data_vars][0].sel(number=ensemble_member),
+                u=[ds['u'] for ds in dataset_pf if 'u' in ds.data_vars][0].sel(number=ensemble_member),
+                v=[ds['v'] for ds in dataset_pf if 'v' in ds.data_vars][0].sel(number=ensemble_member),
+                r=[ds['r'] for ds in dataset_pf if 'r' in ds.data_vars][0].sel(number=ensemble_member),
+                z=[ds['gh'] for ds in dataset_pf if 'gh' in ds.data_vars][0].sel(number=ensemble_member) * 9.81,
+            )
+            for c in channels
+        ]
 
     # dataset_0h is list of Datasets, grab first one 
     # for creating new array


### PR DESCRIPTION
This PR adds support for IFS 0.25-degree control and perturbed forecasts (e.g., control and ensemble) such that either can be instantiated as a `DataSource` in an ensemble inference workflow as in: 

`data_source = ifs.DataSource(time_loop.in_channel_names, ensemble_member=2, from_path="/dev/shm/")` where the `ensemble_member` argument is an integer between 0 to 50, with `0` representing the control forecast and `1-50` representing the perturbed forecast ensemble members. `from_path` represents the local path at which the IFS 0.25-degree grib file is located (for the most recent 6-hourly synoptic time to the datetime specified in the config file). 
