### PR TITLE
Feature/add_dewpoint_temperature_hens

### DIFF
--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -57,7 +57,7 @@ def _get_channel(c: str, **kwargs) -> xarray.DataArray:
 
 
 def get(time: datetime.datetime, channels: List[str], ensemble_member: int, 
-        root_path: str) -> xarray.DataArray:
+        root_path: str, hens: bool) -> xarray.DataArray:
     path = os.path.join(root_path, _get_filename(time, "0h"))
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
@@ -75,6 +75,9 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
 
     # channel variables that do not require renaming
     channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
+
+    if hens:
+        channel_vars = channel_vars.append('2d')
     
     channel_data = [
         _get_channel(
@@ -111,14 +114,21 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
 
 @dataclasses.dataclass
 class DataSource(base.DataSource):
-    def __init__(self, channel_names: List[str], from_path: str, ensemble_member: int = 0):
+    def __init__(self, channel_names: List[str], from_path: str, ensemble_member: int = 0, hens: bool = False):
         self._channel_names = channel_names
         self._ensemble_member = ensemble_member
         self._root_path = from_path
+        self._hens = hens
 
     @property
     def channel_names(self) -> List[str]:
         return self._channel_names
+
+    @property
+    def hens(self) -> bool:
+        # boolean flag that includes dewpoint temperature (2d) if set to True
+        # note that SFNO version that has dewpoint temperature as input channel must be used
+        return self._hens
 
     @property
     def ensemble_member(self) -> int:
@@ -134,7 +144,7 @@ class DataSource(base.DataSource):
 
     def __getitem__(self, time: datetime.datetime) -> np.ndarray:
         ds = get(time, self.channel_names, self.ensemble_member, 
-                self.root_path)
+                self.root_path, self.hens)
 
         # move to earth2mip.channels
         metadata = json.loads(METADATA.read_text())

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -76,9 +76,6 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     # channel variables that do not require renaming
     channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
 
-    # add 2d just to test if it works
-    channels.append('d2m')
-
     if hens:
         # add dewpoint temperature 
         channel_vars.append('d2m')

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -61,7 +61,7 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     path = os.path.join(root_path, _get_filename(time, "0h"))
     # open as list of Datasets given structure of grib 
     dataset_0h = cfgrib.open_datasets(path)
-
+    
     if ensemble_member == 0:
         # control forecast
         dset = [ds for ds in dataset_0h if 0 in ds['number']]
@@ -76,8 +76,12 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     # channel variables that do not require renaming
     channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
 
+    # add 2d just to test if it works
+    channels.append('d2m')
+
     if hens:
-        channel_vars = channel_vars.append('2d')
+        # add dewpoint temperature 
+        channel_vars.append('d2m')
     
     channel_data = [
         _get_channel(

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -127,8 +127,9 @@ class DataSource(base.DataSource):
 
     @property
     def hens(self) -> bool:
-        # boolean flag that includes dewpoint temperature (2d) if set to True
-        # note that SFNO version that has dewpoint temperature as input channel must be used
+        # boolean flag that includes dewpoint temperature (d2m) if set to True
+        # IFS DataSource instantiated with hens set to True must be used 
+        # in conjunction with weights and other input files that include a 74th channel
         return self._hens
 
     @property


### PR DESCRIPTION
This PR adds support for running SFNO with an additional input variable used in the HENS ensemble, dewpoint temperature, in conjunction with the IFS control and perturbed forecasts. To use this feature, the boolean `hens` flag must be set to `True` in instantiating an IFS DataSource object, e.g., 

`data_source = ifs.DataSource(time_loop.in_channel_names, ensemble_member=2, from_path="/dev/shm/", hens=True)`. The default is set to `False`. 