### PR TITLE
Feature/modify ensemble run schema

### DIFF
--- a/earth2mip/schema.py
+++ b/earth2mip/schema.py
@@ -101,6 +101,8 @@ class EnsembleRun(pydantic.BaseModel):
         model_registry (optional): The path to the model registry (alternative to the default, $HOME/.cache/earth2mip/models
 	world_size (optional): Number of accelerators being used for the ensemble inference run
 	model_checkpoint (optional): Checkpoint to use if SFNO HENS weights are being used for inference
+	ic_path (optional): If specified, load initial conditions from this path. Only valid currently for EC IFS. 
+	ensemble_member (optional): If specified, load initial conditions for the ensemble member number provided. Only valid for IFS. 0 indicates the control run. 
 	restart_frequency: if provided save at end and at the specified frequency. 0 = only save at end.
         grf_noise_alpha: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
         grf_noise_sigma: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
@@ -129,6 +131,8 @@ class EnsembleRun(pydantic.BaseModel):
     model_registry: Optional[str] = None
     world_size: Optional[str] = None
     model_checkpoint: Optional[str] = None
+    ic_path: Optional[str] = None
+    ensemble_member: Optional[int] = None
     restart_frequency: Optional[int] = None
     grf_noise_alpha: float = 2.0
     grf_noise_sigma: float = 5.0

--- a/earth2mip/schema.py
+++ b/earth2mip/schema.py
@@ -98,7 +98,7 @@ class EnsembleRun(pydantic.BaseModel):
         weather_event (optional): The weather event to use for the forecast (alternative to `forecast_name`).
         output_dir (optional): The directory to save the output files in (alternative to `output_path`).
         output_path (optional): The path to the output file (alternative to `output_dir`).
-        model_registry (optional): The path to the model registry (alternative to the default, $HOME/.cache/earth2mip/models
+        model_registry (optional): The path to the model registry (alternative to the default, $HOME/.cache/earth2mip/models)
 	world_size (optional): Number of accelerators being used for the ensemble inference run
 	model_checkpoint (optional): Checkpoint to use if SFNO HENS weights are being used for inference
 	ic_path (optional): If specified, load initial conditions from this path. Only valid currently for EC IFS. 

--- a/earth2mip/schema.py
+++ b/earth2mip/schema.py
@@ -98,7 +98,9 @@ class EnsembleRun(pydantic.BaseModel):
         weather_event (optional): The weather event to use for the forecast (alternative to `forecast_name`).
         output_dir (optional): The directory to save the output files in (alternative to `output_path`).
         output_path (optional): The path to the output file (alternative to `output_dir`).
-        restart_frequency: if provided save at end and at the specified frequency. 0 = only save at end.
+        model_registry (optional): The path to the model registry (alternative to the default, $HOME/.cache/earth2mip/models
+	world_size (optional): Number of accelerators being used for the ensemble inference run
+	restart_frequency: if provided save at end and at the specified frequency. 0 = only save at end.
         grf_noise_alpha: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
         grf_noise_sigma: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
         grf_noise_tau: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
@@ -123,6 +125,8 @@ class EnsembleRun(pydantic.BaseModel):
     # alternative for specifying output
     output_dir: Optional[str] = None
     output_path: Optional[str] = None
+    model_registry: Optional[str] = None
+    world_size: Optional[str] = None
     restart_frequency: Optional[int] = None
     grf_noise_alpha: float = 2.0
     grf_noise_sigma: float = 5.0

--- a/earth2mip/schema.py
+++ b/earth2mip/schema.py
@@ -100,6 +100,7 @@ class EnsembleRun(pydantic.BaseModel):
         output_path (optional): The path to the output file (alternative to `output_dir`).
         model_registry (optional): The path to the model registry (alternative to the default, $HOME/.cache/earth2mip/models
 	world_size (optional): Number of accelerators being used for the ensemble inference run
+	model_checkpoint (optional): Checkpoint to use if SFNO HENS weights are being used for inference
 	restart_frequency: if provided save at end and at the specified frequency. 0 = only save at end.
         grf_noise_alpha: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
         grf_noise_sigma: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
@@ -127,6 +128,7 @@ class EnsembleRun(pydantic.BaseModel):
     output_path: Optional[str] = None
     model_registry: Optional[str] = None
     world_size: Optional[str] = None
+    model_checkpoint: Optional[str] = None
     restart_frequency: Optional[int] = None
     grf_noise_alpha: float = 2.0
     grf_noise_sigma: float = 5.0

--- a/earth2mip/schema.py
+++ b/earth2mip/schema.py
@@ -102,7 +102,7 @@ class EnsembleRun(pydantic.BaseModel):
 	world_size (optional): Number of accelerators being used for the ensemble inference run
 	model_checkpoint (optional): Checkpoint to use if SFNO HENS weights are being used for inference
 	ic_path (optional): If specified, load initial conditions from this path. Only valid currently for EC IFS. 
-	ensemble_member (optional): If specified, load initial conditions for the ensemble member number provided. Only valid for IFS. 0 indicates the control run. 
+	ensemble_member (optional): Specifies the IFS ensemble member number, only valid for IFS. 0 indicates the control run. 
 	restart_frequency: if provided save at end and at the specified frequency. 0 = only save at end.
         grf_noise_alpha: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
         grf_noise_sigma: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details


### PR DESCRIPTION
The PR modifies the `EnsembleRun` schema to add some additional optional arguments that are used for HENS probabilistic ensemble inference runs with IFS initial conditions. These mods enable parsing a config file into an `EnsembleRun` object at run-time. They are backwards-compatible as all args added are optional. 