### PR TITLE
Feature/hens fix

### DIFF
--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -80,23 +80,38 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
         # add dewpoint temperature 
         #channel_vars.append('d2m')
     
-    channel_data = [
-        _get_channel(
-            c, 
-            **{var: _subset(var) for var in channel_vars},
-            u10m=_subset('u10'),
-            v10m=_subset('v10'),
-            u100m=_subset('u100'),
-            v100m=_subset('v100'),
-            z=_subset('gh') * 9.81,
-        )   
-        for c in channels
-    ]
-
     if hens:
+        channel_data = [
+            _get_channel(
+                c, 
+                **{var: _subset(var) for var in channel_vars},
+                u10m=_subset('u10'),
+                v10m=_subset('v10'),
+                u100m=_subset('u100'),
+                v100m=_subset('v100'),
+                2d=_subset('d2m'),
+                z=_subset('gh') * 9.81,
+            )   
+            for c in channels
+        ]
+    else:
+        channel_data = [
+            _get_channel(
+                c,
+                **{var: _subset(var) for var in channel_vars},
+                u10m=_subset('u10'),
+                v10m=_subset('v10'),
+                u100m=_subset('u100'),
+                z=_subset('gh') * 9.81,
+            ) 
+            for c in channels
+        ]
+
+
+    #if hens:
         # add dewpoint temperature 
         # needs to be renamed to 2d to match hens weights
-        channel_data.append(2d=_subset('d2m'))
+        # channel_data.append(2d=_subset('d2m'))
 
     # dataset_0h is list of Datasets, grab first one 
     # for creating new array, variable doesn't matter 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -76,9 +76,9 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     # channel variables that do not require renaming
     channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
 
-    if hens:
+    #if hens:
         # add dewpoint temperature 
-        channel_vars.append('d2m')
+        #channel_vars.append('d2m')
     
     channel_data = [
         _get_channel(
@@ -91,7 +91,12 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
             z=_subset('gh') * 9.81,
         )   
         for c in channels
-    ] 
+    ]
+
+    if hens:
+        # add dewpoint temperature 
+        # needs to be renamed to 2d to match hens weights
+        channel_data.append(2d=_subset('d2m'))
 
     # dataset_0h is list of Datasets, grab first one 
     # for creating new array, variable doesn't matter 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -89,7 +89,8 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
                 v10m=_subset('v10'),
                 u100m=_subset('u100'),
                 v100m=_subset('v100'),
-                2d=_subset('d2m'),
+                d2m=_subset('d2m'),
+                q=_subset('q'),
                 z=_subset('gh') * 9.81,
             )   
             for c in channels
@@ -106,7 +107,6 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
             ) 
             for c in channels
         ]
-
 
     #if hens:
         # add dewpoint temperature 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -76,42 +76,27 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
     # channel variables that do not require renaming
     channel_vars = ['sp', 't2m', 'msl', 'tcwv', 't', 'u', 'v', 'r']
 
-    #if hens:
-        # add dewpoint temperature 
-        #channel_vars.append('d2m')
-    
     if hens:
-        channel_data = [
-            _get_channel(
-                c, 
-                **{var: _subset(var) for var in channel_vars},
-                u10m=_subset('u10'),
-                v10m=_subset('v10'),
-                u100m=_subset('u100'),
-                v100m=_subset('v100'),
-                d2m=_subset('d2m'),
-                q=_subset('q'),
-                z=_subset('gh') * 9.81,
-            )   
-            for c in channels
-        ]
-    else:
-        channel_data = [
-            _get_channel(
-                c,
-                **{var: _subset(var) for var in channel_vars},
-                u10m=_subset('u10'),
-                v10m=_subset('v10'),
-                u100m=_subset('u100'),
-                z=_subset('gh') * 9.81,
-            ) 
-            for c in channels
-        ]
-
-    #if hens:
         # add dewpoint temperature 
-        # needs to be renamed to 2d to match hens weights
-        # channel_data.append(2d=_subset('d2m'))
+        # note that dewpoint temperature is actually called 
+        # `2d` in HENS, which can be handled in running ensemble inference by 
+        # renaming the corresponding channel names attribute on an inference object 
+        channel_vars.append('d2m')
+
+        # also add humidity 
+        channel_vars.append('q')
+    
+    channel_data = [
+        _get_channel(
+            c,
+            **{var: _subset(var) for var in channel_vars},
+            u10m=_subset('u10'),
+            v10m=_subset('v10'),
+            u100m=_subset('u100'),
+            z=_subset('gh') * 9.81,
+        ) 
+        for c in channels
+    ]
 
     # dataset_0h is list of Datasets, grab first one 
     # for creating new array, variable doesn't matter 

--- a/earth2mip/initial_conditions/ifs.py
+++ b/earth2mip/initial_conditions/ifs.py
@@ -93,6 +93,7 @@ def get(time: datetime.datetime, channels: List[str], ensemble_member: int,
             u10m=_subset('u10'),
             v10m=_subset('v10'),
             u100m=_subset('u100'),
+            v100m=_subset('v100'),
             z=_subset('gh') * 9.81,
         ) 
         for c in channels


### PR DESCRIPTION
This very brief PR adds humidity (`q`) to the list of variables pulled from IFS initial conditions _if_ HENS checkpoints are being used for running ensemble inference (HENS needs humidity in addition to dewpoint temperature). 

Note that in HENS, dewpoint temperature is actually called `2d` rather than `d2m` as in IFS. We deal with this in a separate routine because that was easiest; however, for anyone else using this workflow, this will need to be addressed while running ensemble inference.  A comment is added to denote this, and specifically the easiest way to address this (to avoid having a variable name starting with an integer) is to update the list of input channel names on an inference object prior to loading initial conditions (as the channel names between ICs and model inputs need to match). 